### PR TITLE
Rename repository to adobestock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# stock-poc
-This repository is the first attempt at bringing Franklin/Milo into the Stock ecosystem. The ongoing effort is captured in this [SPIKE](https://wiki.corp.adobe.com/x/5U7How).
+# adobestock
+This repository is the first attempt at bringing Franklin/Milo into the Stock ecosystem.
 
 ## Developing
 1. Install the [Helix CLI](https://github.com/adobe/helix-cli): `sudo npm install -g @adobe/helix-cli`

--- a/franklin/scripts/scripts/scripts.js
+++ b/franklin/scripts/scripts/scripts.js
@@ -22,7 +22,7 @@ const LIBS = 'https://milo.adobe.com/libs';
 const CONFIG = {
   codeRoot: '/franklin',
   // contentRoot: '',
-  imsClientId: 'stockpoc',
+  imsClientId: 'adobestock',
   // geoRouting: 'off',
   // fallbackRouting: 'off',
   locales: {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@adobe/stock-poc",
+  "name": "@adobe/adobestock",
   "private": true,
   "version": "0.0.1",
-  "description": "PoC demonstrating Franklin/Milo integration in Stock.",
+  "description": "Franklin/Milo integration in Stock.",
   "scripts": {
     "test": "wtr \"./test/**/*.test.js\" --node-resolve --port=2000 --coverage",
     "test:watch": "npm test -- --watch",
@@ -12,14 +12,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adobecom/stockpoc.git"
+    "url": "git+https://github.com/adobecom/adobestock.git"
   },
   "author": "Adobe",
   "license": "Apache License 2.0",
   "bugs": {
-    "url": "https://github.com/adobecom/stockpoc/issues"
+    "url": "https://github.com/adobecom/adobestock/issues"
   },
-  "homepage": "https://github.com/adobecom/stockpoc#readme",
+  "homepage": "https://github.com/adobecom/adobestock#readme",
   "devDependencies": {
     "@babel/core": "7.17.7",
     "@babel/eslint-parser": "7.17.0",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,5 +1,5 @@
 {
-  "project": "Stock POC",
+  "project": "Adobe Stock",
   "host": "www.stock.adobe.com",
   "plugins": [
     {
@@ -21,7 +21,7 @@
       "id": "localize",
       "title": "Localize",
       "environments": [ "edit" ],
-      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=stockpoc--adobecom",
+      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=adobestock--adobecom",
       "passReferrer": true,
       "includePaths": [ "**.xlsx**" ]
     },


### PR DESCRIPTION
Rename all files to adobestock and move away from PoC terminology.

URL for testing:

- https://rename_repo--stockpoc--adobecom.hlx.page/blog/
- https://rename_repo--stockpoc--adobecom.hlx.page/discover/