### PR TITLE
Artist Hub content styling

### DIFF
--- a/franklin/scripts/scripts/scripts.js
+++ b/franklin/scripts/scripts/scripts.js
@@ -118,12 +118,14 @@ function loadFooter() {
 }
 
 (async function loadPage() {
-  document.body.style.visibility = 'hidden';
+  // temporary fix until Milo load template assets differently
+  const template = document.head.querySelector('meta[name="template"]');
+  if (template.content === 'artisthub') document.body.classList.add('artisthub');
+
   const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
 
   setConfig({ ...CONFIG, miloLibs });
   await loadArea();
-  document.body.style.removeProperty('visibility');
   await loadDelayed();
 
   if (!window.location.href.includes('/pages/artisthub')) {

--- a/franklin/scripts/scripts/scripts.js
+++ b/franklin/scripts/scripts/scripts.js
@@ -118,11 +118,12 @@ function loadFooter() {
 }
 
 (async function loadPage() {
-  document.body.style.display = 'none';
+  document.body.style.visibility = 'hidden';
   const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
 
   setConfig({ ...CONFIG, miloLibs });
   await loadArea();
+  document.body.style.removeProperty('visibility');
   await loadDelayed();
 
   if (!window.location.href.includes('/pages/artisthub')) {
@@ -131,5 +132,4 @@ function loadFooter() {
       loadFooter();
     }
   }
-  document.body.style.removeProperty('display');
 }());

--- a/franklin/scripts/scripts/scripts.js
+++ b/franklin/scripts/scripts/scripts.js
@@ -123,8 +123,11 @@ function loadFooter() {
   setConfig({ ...CONFIG, miloLibs });
   await loadArea();
   await loadDelayed();
-  const footer = document.querySelector('footer');
-  if (footer) {
-    loadFooter();
+
+  if (!window.location.href.includes('/pages/artisthub')) {
+    const footer = document.querySelector('footer');
+    if (footer) {
+      loadFooter();
+    }
   }
 }());

--- a/franklin/scripts/scripts/scripts.js
+++ b/franklin/scripts/scripts/scripts.js
@@ -118,6 +118,7 @@ function loadFooter() {
 }
 
 (async function loadPage() {
+  document.body.style.display = 'none';
   const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
 
   setConfig({ ...CONFIG, miloLibs });
@@ -130,4 +131,5 @@ function loadFooter() {
       loadFooter();
     }
   }
+  document.body.style.removeProperty('display');
 }());

--- a/franklin/styles/styles.css
+++ b/franklin/styles/styles.css
@@ -56,7 +56,16 @@
   margin-right: revert !important;
 }
 
+body.artisthub header .gnav .gnav-brand-title {
+  color: #000;
+}
+
 body.artisthub main .section > .content {
-  max-width: 700px;
   padding: var(--spacing-m) 0;
+}
+
+@media(min-width: 1000px) {
+  body.artisthub main .section > .content {
+    max-width: 700px;
+  }
 }

--- a/franklin/styles/styles.css
+++ b/franklin/styles/styles.css
@@ -1,9 +1,9 @@
-/* 
+/*
  * Put project specific base styles here.
  *
  * Note: The proect does not load this file.
  *       You will need to load these using scripts.js.
- * 
+ *
  *
  */
  .footer-wrapper {
@@ -31,7 +31,7 @@
  .footer-info-column:last-child {
   flex-grow: 1;
  }
- 
+
  .footer-privacy-link.footer-left-link:not(:last-child)::after {
   content: '';
  }
@@ -61,7 +61,7 @@ body.artisthub header .gnav .gnav-brand-title {
 }
 
 body.artisthub main .section > .content {
-  padding: var(--spacing-m) 0;
+  padding: 32px 0;
 }
 
 @media(min-width: 1000px) {

--- a/franklin/styles/styles.css
+++ b/franklin/styles/styles.css
@@ -55,3 +55,8 @@
 .footer-region {
   margin-right: revert !important;
 }
+
+body.artisthub main .section > .content {
+  max-width: 700px;
+  padding: var(--spacing-m) 0;
+}

--- a/franklin/styles/styles.css
+++ b/franklin/styles/styles.css
@@ -55,3 +55,17 @@
 .footer-region {
   margin-right: revert !important;
 }
+
+body.artisthub header .gnav .gnav-brand-title {
+  color: #000;
+}
+
+body.artisthub main .section > .content {
+  padding: 32px 0;
+}
+
+@media(min-width: 1000px) {
+  body.artisthub main .section > .content {
+    max-width: 700px;
+  }
+}

--- a/franklin/styles/styles.css
+++ b/franklin/styles/styles.css
@@ -1,7 +1,7 @@
 /*
  * Put project specific base styles here.
  *
- * Note: The proect does not load this file.
+ * Note: The project does not load this file.
  *       You will need to load these using scripts.js.
  *
  *

--- a/franklin/styles/styles.css
+++ b/franklin/styles/styles.css
@@ -55,17 +55,3 @@
 .footer-region {
   margin-right: revert !important;
 }
-
-body.artisthub header .gnav .gnav-brand-title {
-  color: #000;
-}
-
-body.artisthub main .section > .content {
-  padding: 32px 0;
-}
-
-@media(min-width: 1000px) {
-  body.artisthub main .section > .content {
-    max-width: 700px;
-  }
-}

--- a/franklin/templates/artisthub/artisthub.css
+++ b/franklin/templates/artisthub/artisthub.css
@@ -1,0 +1,13 @@
+body.artisthub header .gnav .gnav-brand-title {
+  color: #000;
+}
+
+body.artisthub main .section > .content {
+  padding: 32px 0;
+}
+
+@media(min-width: 1000px) {
+  body.artisthub main .section > .content {
+    max-width: 700px;
+  }
+}

--- a/head.html
+++ b/head.html
@@ -2,5 +2,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/franklin/scripts/scripts/fallback.js" nomodule></script>
 <script src="/franklin/scripts/scripts/scripts.js" type="module"></script>
-<style>body { display: none; }</style>
+<style>body { opacity: 0; }</style>
 <link rel="icon" href="data:,">

--- a/head.html
+++ b/head.html
@@ -2,5 +2,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/franklin/scripts/scripts/fallback.js" nomodule></script>
 <script src="/franklin/scripts/scripts/scripts.js" type="module"></script>
-<style>body { opacity: 0; }</style>
+<style>body { display: none; }</style>
 <link rel="icon" href="data:,">


### PR DESCRIPTION
This is a small pull request to adjust content styling on the Artist Hub website.

Test URLs:
- Before: https://main--adobestock--adobecom.hlx.page/pages/artisthub/learn/disability-representation-in-stock?martech=off
- After: https://artisthub-styling--adobestock--wbstry.hlx.page/pages/artisthub/learn/disability-representation-in-stock?martech=off

The goal is to provide a similar experience to the current production website which can be viewed here:
- https://stock.adobe.com/pages/artisthub/learn/disability-representation-in-stock