### PR TITLE
Fixing cases where the template meta doesn't exist

### DIFF
--- a/franklin/scripts/scripts/scripts.js
+++ b/franklin/scripts/scripts/scripts.js
@@ -120,7 +120,7 @@ function loadFooter() {
 (async function loadPage() {
   // temporary fix until Milo load template assets differently
   const template = document.head.querySelector('meta[name="template"]');
-  if (template.content === 'artisthub') document.body.classList.add('artisthub');
+  if (template?.content === 'artisthub') document.body.classList.add('artisthub');
 
   const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
 


### PR DESCRIPTION
HOTFIX: fixes .live page without template metadata breaks
https://artisthub-styling--adobestock--wbstry.hlx.live/pages/artisthub/get-inspired/seasonal/spring-2021?martech=off