### PR TITLE
Hotfix: Prevent crashing when template is not found

### DIFF
--- a/franklin/scripts/scripts/scripts.js
+++ b/franklin/scripts/scripts/scripts.js
@@ -120,7 +120,7 @@ function loadFooter() {
 (async function loadPage() {
   // temporary fix until Milo load template assets differently
   const template = document.head.querySelector('meta[name="template"]');
-  if (template.content === 'artisthub') document.body.classList.add('artisthub');
+  if (template?.content === 'artisthub') document.body.classList.add('artisthub');
 
   const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
 


### PR DESCRIPTION
This is a PR to prevent the website crashing when a template is not found.

**Test URLs:**
- Before: https://main--adobestock--adobecom.hlx.live/pages/artisthub/learn/disability-representation-in-stock?martech=off
- After: https://template-hotfix--adobestock--wbstry.hlx.live/pages/artisthub/learn/disability-representation-in-stock?martech=off