### PR TITLE
Add Localize V2 option to sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -27,6 +27,16 @@
     },
     {
       "containerId": "tools",
+      "id": "localize-2",
+      "title": "Localize (V2)",
+      "environments": [ "edit" ],
+      "url": "https://main--adobestock--adobecom.hlx.page/tools/loc?milolibs=locui",
+      "passReferrer": true,
+      "passConfig": true,
+      "includePaths": [ "**.xlsx**" ]
+    },
+    {
+      "containerId": "tools",
       "title": "Send to CaaS",
       "id": "sendtocaas",
       "environments": ["dev","preview", "live", "prod"],


### PR DESCRIPTION
Following implementation from [here](https://github.com/adobecom/helpx-internal/pull/48/commits/5e345438cf693493d79a2c0949a6a8aa58b61802), adding Localize v2 for Milo.

URL for testing:

- https://rename_repo--stockpoc--adobecom.hlx.page/blog/