### PR TITLE
Add hlx-5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This repository is the first attempt at bringing Franklin/Milo into the Stock ec
 
 ## Developing
 1. Install the [Helix CLI](https://github.com/adobe/helix-cli): `sudo npm install -g @adobe/helix-cli`
-1. Run `hlx up` this repo's folder. (opens your browser at `http://localhost:3000`)
+1. Run `aem up` this repo's folder. (opens your browser at `http://localhost:3000`)
 1. Open this repo's folder in your favorite editor and start coding.
 
 ## Testing

--- a/franklin/scripts/scripts/utils.js
+++ b/franklin/scripts/scripts/utils.js
@@ -24,16 +24,16 @@ export const [setLibs, getLibs] = (() => {
   return [
     (prodLibs) => {
       const { hostname } = window.location;
-      if (!hostname.includes('hlx.page')
-        && !hostname.includes('hlx.live')
+      if (!hostname.includes('.page')
+        && !hostname.includes('.live')
         && !hostname.includes('localhost')) {
         libs = prodLibs;
         return libs;
       }
       const branch = new URLSearchParams(window.location.search).get('milolibs') || 'main';
       if (branch === 'local') return 'http://localhost:6456/libs';
-      if (branch.indexOf('--') > -1) return `https://${branch}.hlx.page/libs`;
-      return `https://${branch}--milo--adobecom.hlx.live/libs`;
+      if (branch.indexOf('--') > -1) return `https://${branch}.aem.page/libs`;
+      return `https://${branch}--milo--adobecom.aem.live/libs`;
     }, () => libs,
   ];
 })();

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -8,7 +8,7 @@
       "environments": [ "edit" ],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://main--milo--adobecom.hlx.page/tools/library",
+      "url": "https://main--milo--adobecom.aem.page/tools/library",
       "includePaths": [ "**.docx**" ]
     },
     {
@@ -21,7 +21,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--adobestock--adobecom.hlx.page/tools/loc?milolibs=locui",
+      "url": "https://main--adobestock--adobecom.aem.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]


### PR DESCRIPTION
Add hlx5 support

Before: https://main--adobestock--adobecom.hlx.live/pages/artisthub/learn/disability-representation-in-stock?martech=off
After: https://hlx-5--adobestock--adobecom.hlx.live/pages/artisthub/learn/disability-representation-in-stock?martech=off
After-2: https://hlx-5--adobestock--adobecom.aem.live/pages/artisthub/learn/disability-representation-in-stock?martech=off